### PR TITLE
Make the agency check for GSA admin to be case insensitive (#68)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -18,4 +18,11 @@ ignore:
     - winston > async > lodash:
         reason: None given
         expires: '2019-08-02T13:10:53.461Z'
+  SNYK-JS-MINIMIST-559764:
+    - multer > mkdirp > minimist:
+        reason: no fix available
+        expires: '2020-04-11T19:27:49.529Z'
+    - sequelize-cli > js-beautify > mkdirp > minimist:
+        reason: no fix available
+        expires: '2020-04-11T19:27:49.529Z'
 patch: {}

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -113,8 +113,8 @@ module.exports = {
       "Nuclear Regulatory Commission" :	"Nuclear Regulatory Commission",
       "Office of Personnel Management" :	"OFFICE OF PERSONNEL MANAGEMENT",
       "Small Business Administration" :	"Small Business Administration",
-      "Social Security Administration" :	"SOCIAL SECURITY ADMINISTRATION"
-
+      "Social Security Administration" :	"SOCIAL SECURITY ADMINISTRATION",
+      "General Services Administration": "GENERAL SERVICES ADMINISTRATION"
     },
     VisibleNoticeTypes : ['Solicitation', 'Combined Synopsis/Solicitation'],
     "minPredictionCutoffDate" : "2020-02-01T00:00:00.000Z"

--- a/server/routes/auth.routes.js
+++ b/server/routes/auth.routes.js
@@ -321,7 +321,7 @@ async function tokenJsonFromCasInfo (cas_userinfo, secret, expireTime, sessionSt
  * @return {boolean}
  */
 function isGSAAdmin(agency, role) {
-  return  agency === 'General Services Administration' &&
+  return  agency && agency.toLowerCase() === 'general services administration' &&
     (role === roles[ADMIN_ROLE].name || role === roles[PROGRAM_MANAGER_ROLE].name)
 }
 

--- a/server/tests/token.test.js
+++ b/server/tests/token.test.js
@@ -244,5 +244,12 @@ describe('JWT Tests', () => {
     expect(energy).toBe("Department of Energy")
     delete process.env.AGENCY_LOOKUP
 
+    // test the env var override
+    process.env.AGENCY_LOOKUP = '{ "Department of Agriculture" : "AGRICULTURE, DEPARTMENT OF", "Department of Commerce": "COMMERCE, DEPARTMENT OF", "Department of Education" : "Department of Education", "Department of Health and Human Services" : "HEALTH AND HUMAN SERVICES, DEPARTMENT OF", "Department of Homeland Security": "HOMELAND SECURITY, DEPARTMENT OF", "Department of Housing and Urban Development" : "Department of Housing and Urban Development", "Department of Justice" : "JUSTICE, DEPARTMENT OF", "Department of Labor" : "LABOR, DEPARTMENT OF", "Department of State" : "STATE, DEPARTMENT OF", "Department of the Interior": "INTERIOR, DEPARTMENT OF THE", "Department of the Treasury": "TREASURY, DEPARTMENT OF THE", "Department of Transportation" : "TRANSPORTATION, DEPARTMENT OF", "Environmental Protection Agency" : "ENVIRONMENTAL PROTECTION AGENCY", "Executive Office of the President" : "Executive Office of the President", "International Assistance Programs" : "AGENCY FOR INTERNATIONAL DEVELOPMENT", "National Aeronautics and Space Administration" : "NATIONAL AERONAUTICS AND SPACE ADMINISTRATION", "National Science Foundation" : "National Science Foundation", "Nuclear Regulatory Commission" : "Nuclear Regulatory Commission", "Office of Personnel Management" : "OFFICE OF PERSONNEL MANAGEMENT", "Small Business Administration" : "Small Business Administration", "Social Security Administration" : "SOCIAL SECURITY ADMINISTRATION", "General Services Administration": "GENERAL SERVICES ADMINISTRATION" }'
+    let gsa = authRoutes.translateCASAgencyName("General Services Administration")
+    expect(gsa).toBe("GENERAL SERVICES ADMINISTRATION")
+    delete process.env.AGENCY_LOOKUP
+
+
   })
 })


### PR DESCRIPTION
* Adding GSA to agency mapping

* Make the agency check for GSA admin to be case insensitive
That's needed to account for the MAX->sam.gov mapping of agency names.

* Delaying snyk security alert for 30 days b/c there isn't a patch available yet