### PR TITLE
Adding Cannot Evaluate to analytics route

### DIFF
--- a/server/routes/analytics.routes.js
+++ b/server/routes/analytics.routes.js
@@ -164,6 +164,11 @@ async function computeAnalytics (params, user) {
       LatestNotApplicableSolicitation: 0,
       FilteredNotApplicableSolicitation: 0,
 
+      // Number of Cannot Evaluate Solicitation
+      TotalCannotEvaluateSolicitation: 0,
+      LatestCannotEvaluateSolicitation: 0,
+      FilteredCannotEvaluateSolicitation: 0,
+
       // Update
       LatestUpdateCompliance: 0,
       LatestUpdateNonCompliance: 0,
@@ -277,12 +282,16 @@ async function computeAnalytics (params, user) {
               data.LatestComplianceSolicitation++
             } else if (predictions[i].predictions.value === 'grey') {
               data.LatestNotApplicableSolicitation++
+            } else if (predictions[i].predictions.value === 'yellow') {
+              data.LatestCannotEvaluateSolicitation++
             } else data.LatestNonComplianceSolicitation++
           }
           if (predictions[i].predictions.value === 'green') {
             data.TotalComplianceSolicitation++
           } else if (predictions[i].predictions.value === 'grey') {
             data.TotalNotApplicableSolicitation++
+          } else if (predictions[i].predictions.value === 'yellow') {
+            data.TotalCannotEvaluateSolicitation++
           } else data.TotalNonComplianceSolicitation++
 
           // scanned solicitation chart
@@ -414,7 +423,8 @@ async function computeAnalytics (params, user) {
         {
           compliance: data.LatestComplianceSolicitation,
           uncompliance: data.LatestNonComplianceSolicitation,
-          notApplicable: data.LatestNotApplicableSolicitation
+          notApplicable: data.LatestNotApplicableSolicitation,
+          cannotEvaluate: data.LatestCannotEvaluateSolicitation
         },
       UndeterminedSolicitationChart:
         {

--- a/server/version.json
+++ b/server/version.json
@@ -1,1 +1,1 @@
-{ "version" : "v1.2.0dev0" , "build_date" : "2023-09-05.10.30.00" } 
+{ "version" : "v1.2.0dev1" , "build_date" : "2023-09-05.10.30.00" } 


### PR DESCRIPTION
# Change
- Tracking data on predictions that have a value of "yellow" for the cannot evaluate category. 