### PR TITLE
Security updates 04/23/2024

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "express": "^4.17.1",
         "express-session": "^1.17.3",
         "express-winston": "^3.4.0",
-        "flatted": "^3.2.9",
+        "flatted": "^3.3.0",
         "json2csv": "^5.0.7",
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
@@ -5528,9 +5528,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.0.tgz",
+      "integrity": "sha512-noqGuLw158+DuD9UPRKHpJ2hGxpFyDlYYrfM0mWt4XhT4n0lwzTLh70Tkdyy4kyTmyTT9Bv7bWAJqw7cgkEXDg=="
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -19685,9 +19685,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.0.tgz",
+      "integrity": "sha512-noqGuLw158+DuD9UPRKHpJ2hGxpFyDlYYrfM0mWt4XhT4n0lwzTLh70Tkdyy4kyTmyTT9Bv7bWAJqw7cgkEXDg=="
     },
     "fn.name": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.3",
     "express-winston": "^3.4.0",
-    "flatted": "^3.2.9",
+    "flatted": "^3.3.0",
     "json2csv": "^5.0.7",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
# Security Updates:
- [fix: upgrade @snyk/protect from 1.1272.0 to 1.1278.0](https://github.com/GSA/srt-api/commit/b7883b3c33235a817fc537ef21744a748747d392)
- [fix: upgrade openid-client from 5.6.1 to 5.6.4](https://github.com/GSA/srt-api/commit/660c0e40832a1c9ae0e341643bfa873a4c3b2352)
- [fix: upgrade express-session from 1.17.3 to 1.18.0](https://github.com/GSA/srt-api/commit/5d0d660036893b048037fdb8cbda15044bd00e61)
- [fix: upgrade sequelize from 6.35.2 to 6.36.0](https://github.com/GSA/srt-api/commit/7792b0478c8d97dfe05d2c6487d7e4b80595d23a)
- [fix: upgrade flatted from 3.2.9 to 3.3.0](https://github.com/GSA/srt-api/commit/8b1170246b19f1a4461e1ceb1e7a7c6c3ad02bb6)