### PR TITLE
Grabbing Gov email in Login.gov all_emails

### DIFF
--- a/server/routes/prediction.routes.js
+++ b/server/routes/prediction.routes.js
@@ -554,7 +554,7 @@ module.exports = {
     let keys = Object.keys(req.body)
 
     // verify that only supported filter params are used
-    let validKeys = ['agency', 'office', 'numDocs', 'solNum', 'category_list', 'startDate', 'fromPeriod', 'endDate', 'toPeriod']
+    let validKeys = ['agency', 'office', 'numDocs', 'solNum', 'category_list', 'startDate', 'fromPeriod', 'endDate', 'toPeriod', 'noticeType']
     // add in the keys used by the PrimeNG table lazy loader
     validKeys.push('first', 'filters', 'globalFilter', 'multiSortMeta', 'rows', 'sortField', 'sortOrder')
     for (let i = 0; i < keys.length; i++) {

--- a/server/tests/auth.routes.test.js
+++ b/server/tests/auth.routes.test.js
@@ -11,6 +11,7 @@ const User = require('../models').User
 const authRoutes = require('../routes/auth.routes')
 const logger = require('../config/winston')
 const mocks = require('./mocks')
+const { getGovernmentEmail } = require('../routes/auth.routes');
 
 const { userAcceptedCASData } = require('./test.data');
 
@@ -526,4 +527,26 @@ describe('/api/auth/', () => {
       {'cas_userinfo':{'email-address': 'arron.smith@gsa.gov'}})).toBeFalse();
   })
 
-  })
+})
+
+describe('getGovernmentEmail', () => {
+  test('returns the first .gov email if present', () => {
+    const emails = ['user@example.com', 'user@agency.gov', 'user@another.com'];
+    expect(getGovernmentEmail(emails)).toBe('user@agency.gov');
+  });
+
+  test('returns the first .mil email if present', () => {
+    const emails = ['user@example.com', 'user@agency.mil', 'user@another.com'];
+    expect(getGovernmentEmail(emails)).toBe('user@agency.mil');
+  });
+
+  test('returns null if no .gov or .mil email is present', () => {
+    const emails = ['user@example.com', 'user@another.com'];
+    expect(getGovernmentEmail(emails)).toBe(null);
+  });
+
+  test('returns null if the emails array is empty', () => {
+    const emails = [];
+    expect(getGovernmentEmail(emails)).toBe(null);
+  });
+});


### PR DESCRIPTION
# Changes:
* Utilizes the all_emails field to verify an existing gov email is located
* Additionally, pulls the government email out of the all_emails rsp field
* Added unit tests for this new function